### PR TITLE
Refine particle animations to mimic scatter plot

### DIFF
--- a/src/components/NoiseParticles.tsx
+++ b/src/components/NoiseParticles.tsx
@@ -22,7 +22,7 @@ export const NoiseParticles = () => {
     if (!ctx) return;
 
     const particles: Particle[] = [];
-    const particleCount = 100;
+    const particleCount = 300;
 
     const resizeCanvas = () => {
       canvas.width = canvas.offsetWidth;
@@ -32,9 +32,9 @@ export const NoiseParticles = () => {
     const createParticle = (): Particle => ({
       x: Math.random() * canvas.width,
       y: Math.random() * canvas.height,
-      vx: (Math.random() - 0.5) * 0.5,
-      vy: (Math.random() - 0.5) * 0.5,
-      size: Math.random() * 2 + 0.5,
+      vx: 0,
+      vy: 0,
+      size: Math.random() * 1 + 0.3,
       opacity: Math.random() * 0.3 + 0.1,
       life: 0,
       maxLife: Math.random() * 300 + 200
@@ -50,12 +50,12 @@ export const NoiseParticles = () => {
     const updateParticles = () => {
       particles.forEach((particle, index) => {
         // Add noise to movement
-        particle.vx += (Math.random() - 0.5) * 0.02;
-        particle.vy += (Math.random() - 0.5) * 0.02;
+        particle.vx += (Math.random() - 0.5) * 0.01;
+        particle.vy += (Math.random() - 0.5) * 0.01;
         
         // Apply velocity damping
-        particle.vx *= 0.995;
-        particle.vy *= 0.995;
+        particle.vx *= 0.99;
+        particle.vy *= 0.99;
         
         // Update position
         particle.x += particle.vx;

--- a/src/components/ParticlesBackground.tsx
+++ b/src/components/ParticlesBackground.tsx
@@ -27,25 +27,8 @@ export const ParticlesBackground = () => {
         fpsLimit: 120,
         interactivity: {
           events: {
-            onClick: {
-              enable: true,
-              mode: "push",
-            },
-            onHover: {
-              enable: true,
-              mode: "repulse",
-            },
             resize: {
-              enable: true
-            },
-          },
-          modes: {
-            push: {
-              quantity: 4,
-            },
-            repulse: {
-              distance: 200,
-              duration: 0.4,
+              enable: true,
             },
           },
         },
@@ -54,36 +37,25 @@ export const ParticlesBackground = () => {
             value: ["#10b981", "#059669", "#047857"],
           },
           links: {
-            color: "#10b981",
-            distance: 150,
-            enable: true,
-            opacity: 0.3,
-            width: 1,
+            enable: false,
           },
           move: {
-            direction: "none",
-            enable: true,
-            outModes: {
-              default: "bounce",
-            },
-            random: false,
-            speed: 2,
-            straight: false,
+            enable: false,
           },
           number: {
             density: {
               enable: true,
             },
-            value: 80,
+            value: 200,
           },
           opacity: {
-            value: 0.5,
+            value: 0.8,
           },
           shape: {
             type: "circle",
           },
           size: {
-            value: { min: 1, max: 5 },
+            value: { min: 0.5, max: 2 },
           },
         },
         detectRetina: true,


### PR DESCRIPTION
## Summary
- Intensify particle density and shrink particle size for scatter-like background
- Increase canvas particle count with subtle motion for clustered scatter effect

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any types and require imports)*

------
https://chatgpt.com/codex/tasks/task_e_688d733ae9c08330bf1c3f1871845804