### PR TITLE
Refine particle animations to mimic scatter plot

### DIFF
--- a/src/components/NoiseParticles.tsx
+++ b/src/components/NoiseParticles.tsx
@@ -21,24 +21,32 @@ export const NoiseParticles = () => {
     const ctx = canvas.getContext('2d');
     if (!ctx) return;
 
-    const particles: Particle[] = [];
-    const particleCount = 100;
+      const particles: Particle[] = [];
+      const particleCount = 400;
 
-    const resizeCanvas = () => {
-      canvas.width = canvas.offsetWidth;
-      canvas.height = canvas.offsetHeight;
-    };
+      const resizeCanvas = () => {
+        canvas.width = canvas.offsetWidth;
+        canvas.height = canvas.offsetHeight;
+      };
 
-    const createParticle = (): Particle => ({
-      x: Math.random() * canvas.width,
-      y: Math.random() * canvas.height,
-      vx: (Math.random() - 0.5) * 0.5,
-      vy: (Math.random() - 0.5) * 0.5,
-      size: Math.random() * 2 + 0.5,
-      opacity: Math.random() * 0.3 + 0.1,
-      life: 0,
-      maxLife: Math.random() * 300 + 200
-    });
+      const createParticle = (): Particle => {
+        const centerX = canvas.width / 2;
+        const centerY = canvas.height / 2;
+        const maxRadius = Math.min(canvas.width, canvas.height) * 0.2;
+        const angle = Math.random() * Math.PI * 2;
+        const radius = Math.random() * maxRadius;
+
+        return {
+          x: centerX + Math.cos(angle) * radius,
+          y: centerY + Math.sin(angle) * radius,
+          vx: 0,
+          vy: 0,
+          size: Math.random() * 0.4 + 0.1,
+          opacity: Math.random() * 0.3 + 0.1,
+          life: 0,
+          maxLife: Math.random() * 300 + 200
+        };
+      };
 
     const initParticles = () => {
       particles.length = 0;
@@ -50,12 +58,12 @@ export const NoiseParticles = () => {
     const updateParticles = () => {
       particles.forEach((particle, index) => {
         // Add noise to movement
-        particle.vx += (Math.random() - 0.5) * 0.02;
-        particle.vy += (Math.random() - 0.5) * 0.02;
+        particle.vx += (Math.random() - 0.5) * 0.01;
+        particle.vy += (Math.random() - 0.5) * 0.01;
         
         // Apply velocity damping
-        particle.vx *= 0.995;
-        particle.vy *= 0.995;
+        particle.vx *= 0.99;
+        particle.vy *= 0.99;
         
         // Update position
         particle.x += particle.vx;
@@ -71,11 +79,18 @@ export const NoiseParticles = () => {
           particle.opacity = ((particle.maxLife - particle.life) / (particle.maxLife * 0.1)) * 0.3;
         }
         
-        // Wrap around edges
-        if (particle.x < 0) particle.x = canvas.width;
-        if (particle.x > canvas.width) particle.x = 0;
-        if (particle.y < 0) particle.y = canvas.height;
-        if (particle.y > canvas.height) particle.y = 0;
+          // Keep particles within central cluster
+          const centerX = canvas.width / 2;
+          const centerY = canvas.height / 2;
+          const maxRadius = Math.min(canvas.width, canvas.height) * 0.2;
+          const dx = particle.x - centerX;
+          const dy = particle.y - centerY;
+          const distance = Math.sqrt(dx * dx + dy * dy);
+          if (distance > maxRadius) {
+            const ratio = maxRadius / distance;
+            particle.x = centerX + dx * ratio;
+            particle.y = centerY + dy * ratio;
+          }
         
         // Reset particle if life exceeded
         if (particle.life >= particle.maxLife) {

--- a/src/components/ParticlesBackground.tsx
+++ b/src/components/ParticlesBackground.tsx
@@ -1,5 +1,10 @@
-import { useCallback } from "react";
-import type { Container, Engine } from "@tsparticles/engine";
+import { useCallback, useMemo } from "react";
+import type {
+  Container,
+  Engine,
+  IManualParticle,
+  ISourceOptions,
+} from "@tsparticles/engine";
 import Particles from "@tsparticles/react";
 import { loadSlim } from "@tsparticles/slim";
 
@@ -15,79 +20,44 @@ export const ParticlesBackground = () => {
     []
   );
 
+  const manualParticles = useMemo<IManualParticle[]>(
+    () =>
+      Array.from({ length: 300 }, () => ({
+        position: {
+          x: 50 + (Math.random() - 0.5) * 20,
+          y: 50 + (Math.random() - 0.5) * 20,
+        },
+      })),
+    []
+  );
+
+  const options: ISourceOptions = {
+    background: {
+      color: { value: "transparent" },
+    },
+    fpsLimit: 120,
+    interactivity: {
+      events: {
+        resize: { enable: true },
+      },
+    },
+    manualParticles,
+    particles: {
+      color: { value: ["#10b981", "#059669", "#047857"] },
+      links: { enable: false },
+      move: { enable: false },
+      number: { value: 0 },
+      opacity: { value: 0.8 },
+      shape: { type: "circle" },
+      size: { value: { min: 0.3, max: 1 } },
+    },
+    detectRetina: true,
+  };
+
   return (
     <Particles
       id="tsparticles"
-      options={{
-        background: {
-          color: {
-            value: "transparent",
-          },
-        },
-        fpsLimit: 120,
-        interactivity: {
-          events: {
-            onClick: {
-              enable: true,
-              mode: "push",
-            },
-            onHover: {
-              enable: true,
-              mode: "repulse",
-            },
-            resize: {
-              enable: true
-            },
-          },
-          modes: {
-            push: {
-              quantity: 4,
-            },
-            repulse: {
-              distance: 200,
-              duration: 0.4,
-            },
-          },
-        },
-        particles: {
-          color: {
-            value: ["#10b981", "#059669", "#047857"],
-          },
-          links: {
-            color: "#10b981",
-            distance: 150,
-            enable: true,
-            opacity: 0.3,
-            width: 1,
-          },
-          move: {
-            direction: "none",
-            enable: true,
-            outModes: {
-              default: "bounce",
-            },
-            random: false,
-            speed: 2,
-            straight: false,
-          },
-          number: {
-            density: {
-              enable: true,
-            },
-            value: 80,
-          },
-          opacity: {
-            value: 0.5,
-          },
-          shape: {
-            type: "circle",
-          },
-          size: {
-            value: { min: 1, max: 5 },
-          },
-        },
-        detectRetina: true,
-      }}
+      options={options}
       className="absolute inset-0 w-full h-full"
     />
   );


### PR DESCRIPTION
## Summary
- Concentrate tsparticles around center using manual positions for static scatter cloud
- Spawn custom noise particles within a central radius and confine drift to maintain cluster

## Testing
- `npx eslint src/components/NoiseParticles.tsx src/components/ParticlesBackground.tsx`
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unexpected any types and require imports in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_688d733ae9c08330bf1c3f1871845804