### PR TITLE
feat: expand tools section by default

### DIFF
--- a/src/components/AppSidebar.tsx
+++ b/src/components/AppSidebar.tsx
@@ -35,7 +35,7 @@ export function AppSidebar() {
   const [adminOpen, setAdminOpen] = useState(true)
   const [wealthOpen, setWealthOpen] = useState(true)
   const [portfoliosOpen, setPortfoliosOpen] = useState(true)
-  const [toolsOpen, setToolsOpen] = useState(false)
+  const [toolsOpen, setToolsOpen] = useState(true)
 
   const isActive = (path: string) => currentPath === path || currentPath.startsWith(path)
   const getNavCls = ({ isActive }: { isActive: boolean }) =>


### PR DESCRIPTION
## Summary
- default Tools & Analytics section is open in the sidebar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: ✖ 49 problems (28 errors, 21 warnings))*


------
https://chatgpt.com/codex/tasks/task_e_688ff6de389c83308e934d42b08b59dd