### PR TITLE
feat: add glowing circles section to landing

### DIFF
--- a/src/components/GlowingCircles.tsx
+++ b/src/components/GlowingCircles.tsx
@@ -1,0 +1,10 @@
+export function GlowingCircles() {
+  return (
+    <div className="relative w-[200px] h-[120px]">
+      <div className="absolute w-[120px] h-[120px] bg-primary rounded-full blur-xl opacity-80" />
+      <div className="absolute left-10 w-[120px] h-[120px] bg-primary rounded-full blur-xl mix-blend-screen" />
+    </div>
+  );
+}
+
+export default GlowingCircles;

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -6,6 +6,7 @@ import { ParticlesBackground } from "@/components/ParticlesBackground";
 import { NoiseParticles } from "@/components/NoiseParticles";
 import { PortfolioChart } from "@/components/PortfolioChart";
 import { TickerTape } from "@/components/TickerTape";
+import { GlowingCircles } from "@/components/GlowingCircles";
 
 const Landing = () => {
   const features = [
@@ -99,6 +100,19 @@ const Landing = () => {
               <Zap className="w-5 h-5 mr-2" />
               Watch Demo
             </Button>
+          </div>
+        </div>
+      </section>
+
+      {/* Glowing Circles Section */}
+      <section className="container mx-auto px-4 py-20">
+        <div className="relative flex items-center justify-center">
+          <GlowingCircles />
+          <div className="absolute inset-0 flex flex-col items-center justify-center text-center space-y-4">
+            <h3 className="text-3xl font-bold">Illuminate Your Strategy</h3>
+            <p className="text-muted-foreground max-w-md mx-auto">
+              Add your custom message or call to action here.
+            </p>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- add reusable GlowingCircles component for green glow effect
- showcase GlowingCircles section on landing page with overlaid text

## Testing
- `npm run lint` *(fails: Unexpected any in admin pages and require usage in tailwind config)*

------
https://chatgpt.com/codex/tasks/task_e_688ff8f0346c83309f6665077b086b8f