### PR TITLE
Rename Flow designer references to Asset Composer

### DIFF
--- a/src/pages/Assets.tsx
+++ b/src/pages/Assets.tsx
@@ -297,7 +297,7 @@ const Assets = () => {
     }
   }
 
-  const editInFlow = (assetId: string) => {
+  const editInAssetComposer = (assetId: string) => {
     navigate(`/asset-composer?asset=${assetId}`)
   }
 
@@ -532,10 +532,10 @@ const Assets = () => {
                       <Button
                         variant="outline"
                         size="sm"
-                        onClick={() => editInFlow(asset.id)}
+                        onClick={() => editInAssetComposer(asset.id)}
                       >
                         <GitBranch className="w-4 h-4 mr-2" />
-                        Edit in Flow
+                        Edit in Asset Composer
                       </Button>
                       
                       <Button

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -32,7 +32,7 @@ const Landing = () => {
     {
       icon: GitBranch,
       title: "Workflow Automation",
-      description: "Visual flow designer for automated trading strategies and rebalancing."
+      description: "Visual asset composer for automated trading strategies and rebalancing."
     },
     {
       icon: Database,


### PR DESCRIPTION
## Summary
- rename Flow designer text to Asset Composer
- update Assets page button to open in Asset Composer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_689143aaf5088330acd09982f2be56c6