### PR TITLE
Replace Flow designer sidebar entry

### DIFF
--- a/src/hooks/useModuleAccess.tsx
+++ b/src/hooks/useModuleAccess.tsx
@@ -39,7 +39,13 @@ export const useModuleAccess = () => {
         return;
       }
 
-      setModules(data || []);
+      const transformedData = (data || []).map((module: SystemModule) =>
+        module.module_id === 'flow_designer'
+          ? { ...module, name: 'Asset Composer', path: '/asset-composer', icon: 'Workflow' }
+          : module
+      );
+
+      setModules(transformedData);
     } catch (error) {
       console.error('Error fetching user modules:', error);
     } finally {


### PR DESCRIPTION
## Summary
- remap deprecated `flow_designer` module to `Asset Composer` so sidebar opens asset composer view

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68914a86948083308cdb6d5a340a5134